### PR TITLE
Bump grunt-bower-task

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "grunt": "~0.4.4",
     "grunt-autoprefixer": "~0.6.5",
     "grunt-banner": "latest",
-    "grunt-bower-task": "~0.3.2",
+    "grunt-bower-task": "~0.4.0",
     "grunt-cfpb-internal": "git://github.com/cfpb/grunt-cfpb-internal.git",
     "grunt-contrib-clean": "latest",
     "grunt-contrib-compress": "latest",


### PR DESCRIPTION
Update `grunt-bower-task` to avoid the _[Arguments to path.join must be strings](https://github.com/bower/bower/pull/1403)_ bug.
